### PR TITLE
一つ前に戻るボタンを追加

### DIFF
--- a/components/pages/events/EventPagePresenter.tsx
+++ b/components/pages/events/EventPagePresenter.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 import { chakra, useDisclosure } from "@chakra-ui/react";
+import { path } from "routes/path";
 import { Header } from "../../shared/Header";
 import { FooterNavBar } from "../../shared/FooterNavBar";
 import { EventList } from "./components/EventList";
@@ -28,6 +29,12 @@ export const EventPagePresenter: FC<Props> = ({ group, events, users }) => {
   return (
     <>
       <Header title={group.name} onClickPlusButton={onOpen} />
+      <chakra.div padding="5px" backgroundColor="#EFEFEF">
+        <chakra.a
+          href={path.top()}
+          fontSize="14px"
+        >{`< グループ一覧に戻る`}</chakra.a>
+      </chakra.div>
       <chakra.div width="100%" display="flex">
         <chakra.div
           width="50%"

--- a/components/pages/events/components/EventList/EventListPresenter.tsx
+++ b/components/pages/events/components/EventList/EventListPresenter.tsx
@@ -12,7 +12,7 @@ type Props = Array<{
 export const EventListPresenter: FC<{ events: Props }> = ({ events }) => (
   <chakra.ul
     width="100%"
-    height="calc(100vh - 200px)"
+    height="calc(100vh - 234px)"
     overflow="scroll"
     whiteSpace="nowrap"
     cursor="pointer"

--- a/components/pages/expences/ExpencePagePresenter.tsx
+++ b/components/pages/expences/ExpencePagePresenter.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 import { chakra, useDisclosure } from "@chakra-ui/react";
+import { path } from "routes/path";
 import { Header } from "../../shared/Header";
 import { FooterNavBar } from "../../shared/FooterNavBar";
 import { ExpenceLists } from "./components/ExpenceLists";
@@ -7,6 +8,9 @@ import { UserLists } from "./components/UserLists";
 import { ExpenceCreateModal } from "./components/ExpenceCreateModal";
 
 type Props = {
+  group: {
+    id: number;
+  };
   event: {
     name: string;
   };
@@ -24,12 +28,23 @@ type Props = {
   }>;
 };
 
-export const ExpencePagePresenter: FC<Props> = ({ event, expences, users }) => {
+export const ExpencePagePresenter: FC<Props> = ({
+  group,
+  event,
+  expences,
+  users,
+}) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [selected, setSelected] = React.useState<"expence" | "user">("expence");
   return (
     <>
       <Header title={event.name} onClickPlusButton={onOpen} />
+      <chakra.div padding="5px" backgroundColor="#EFEFEF">
+        <chakra.a
+          href={path.events(String(group.id))}
+          fontSize="14px"
+        >{`< イベント一覧に戻る`}</chakra.a>
+      </chakra.div>
       <chakra.div width="100%" display="flex">
         <chakra.div
           width="50%"

--- a/components/pages/expences/__dev__/mockData.ts
+++ b/components/pages/expences/__dev__/mockData.ts
@@ -1,4 +1,7 @@
 export const expencesMockData = {
+  group: {
+    id: 1,
+  },
   event: {
     name: "イベント名",
   },

--- a/components/pages/expences/components/ExpenceLists/ExpenceListsPresenter.tsx
+++ b/components/pages/expences/components/ExpenceLists/ExpenceListsPresenter.tsx
@@ -15,7 +15,7 @@ export const ExpenceListsPresenter: FC<{ expences: Props }> = ({
   <>
     <chakra.ul
       width="100%"
-      height="calc(100vh - 200px)"
+      height="calc(100vh - 234px)"
       overflow="scroll"
       whiteSpace="nowrap"
       cursor="pointer"


### PR DESCRIPTION
## 概要

- イベントページには「グループ一覧に戻る」ボタンを、支出ページには「イベント一覧に戻る」ボタンをそれぞれ追加した。

## 背景

- 上記2つのページからはアプリ内で前のページに戻る導線がなかったため、UX向上のために実装した

## テスト項目とテスト結果

- ローカルで動かして動くことを確認
